### PR TITLE
feat: add GitHub-style alerts/callouts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@shikijs/transformers": "^3.20.0",
         "markdown-it": "^14.1.0",
+        "markdown-it-github-alerts": "^1.0.0",
         "markdown-it-mark": "^4.0.0",
       },
       "devDependencies": {
@@ -141,6 +142,8 @@
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
 
     "markdown-it": ["markdown-it@14.1.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg=="],
+
+    "markdown-it-github-alerts": ["markdown-it-github-alerts@1.0.0", "", { "peerDependencies": { "markdown-it": ">= 13.0.0" } }, "sha512-RU3cbB/ewujrDpYNdyabvp4CscZ5J/3D71NWbJW+JSA0nplfutIXDMCwtGWlMLwzgBDAYkFMvYGkigq8nWOVdA=="],
 
     "markdown-it-mark": ["markdown-it-mark@4.0.0", "", {}, "sha512-YLhzaOsU9THO/cal0lUjfMjrqSMPjjyjChYM7oyj4DnyaXEzA8gnW6cVJeyCrCVeyesrY2PlEdUYJSPFYL4Nkg=="],
 

--- a/docs.md
+++ b/docs.md
@@ -149,6 +149,29 @@ Combine multiple keys:
 <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> opens the command palette.
 ```
 
+## Alerts / Callouts
+
+GitHub-style alerts for highlighting important information:
+
+```markdown
+> [!NOTE]
+> Useful information the user should know.
+
+> [!TIP]
+> Helpful advice for better outcomes.
+
+> [!IMPORTANT]
+> Key information for success.
+
+> [!WARNING]
+> Urgent info requiring immediate attention.
+
+> [!CAUTION]
+> Potential negative consequences.
+```
+
+Five types available: `NOTE` (blue), `TIP` (green), `IMPORTANT` (purple), `WARNING` (yellow), `CAUTION` (red).
+
 ## Customization
 
 Override font size and line height in your note type's Styling section (**Browse > Cards > Styling**):

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@shikijs/transformers": "^3.20.0",
     "markdown-it": "^14.1.0",
+    "markdown-it-github-alerts": "^1.0.0",
     "markdown-it-mark": "^4.0.0"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import './style.css'
 import MarkdownIt from 'markdown-it'
 import mark from 'markdown-it-mark'
+import alerts from 'markdown-it-github-alerts'
 import { createHighlighter, bundledLanguages } from 'shiki/bundle/web'
 import swift from 'shiki/langs/swift.mjs'
 import rust from 'shiki/langs/rust.mjs'
@@ -89,7 +90,7 @@ function highlight(code: string, lang: string, meta?: string) {
   }
 }
 
-const md = MarkdownIt({ html: true }).use(mark)
+const md = MarkdownIt({ html: true }).use(mark).use(alerts)
 
 // Fence renderer: ```lang meta
 md.renderer.rules.fence = (tokens, idx) => {

--- a/src/style.css
+++ b/src/style.css
@@ -177,9 +177,31 @@ code:not(.shiki code) {
 }
 
 mark {
+  color: var(--fg);
   background: rgb(255 255 0 / 0.3);
   padding: 1px 2px;
   border-radius: 2px;
+
+  .nightMode & {
+    background: rgb(255 255 0 / 0.4);
+  }
+}
+
+ul, ol {
+  margin: 1em 0;
+  padding-left: 1.5em;
+}
+
+li {
+  margin: 0;
+
+  p {
+    margin: 0;
+  }
+
+  ul, ol {
+    margin: 0;
+  }
 }
 
 blockquote {
@@ -201,6 +223,55 @@ kbd {
   border: 1px solid var(--border);
   border-radius: 4px;
   box-shadow: 0 1px 0 var(--border);
+}
+
+/* GitHub-style alerts */
+.markdown-alert {
+  margin: 1em 0;
+  padding: 0.35em 0.75em;
+  font-size: 0.9em;
+  border-left: 3px solid var(--alert-color, var(--border));
+  background: color-mix(in srgb, var(--alert-color, var(--border)) 10%, transparent);
+  border-radius: 4px;
+
+  .markdown-alert-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    margin: 0;
+    font-weight: 600;
+    color: var(--alert-color);
+
+    svg {
+      width: 1em;
+      height: 1em;
+      fill: currentColor;
+    }
+  }
+
+  p:last-child {
+    margin: 0;
+  }
+}
+
+.markdown-alert-note {
+  --alert-color: #2563eb;
+}
+
+.markdown-alert-tip {
+  --alert-color: #16a34a;
+}
+
+.markdown-alert-important {
+  --alert-color: #7c3aed;
+}
+
+.markdown-alert-warning {
+  --alert-color: #ca8a04;
+}
+
+.markdown-alert-caution {
+  --alert-color: #dc2626;
 }
 
 @property --fade-left {

--- a/test/kitchensink.html
+++ b/test/kitchensink.html
@@ -214,6 +214,25 @@ CSS:
   color: rgb(0 0 0 / 0.8);
 }
 \`\`\`
+
+---
+
+## Alerts / Callouts
+
+> [!NOTE]
+> This is a note with helpful information.
+
+> [!TIP]
+> This is a tip with optional guidance.
+
+> [!IMPORTANT]
+> This is important information you should know.
+
+> [!WARNING]
+> This is a warning about potential issues.
+
+> [!CAUTION]
+> This is a caution about negative consequences.
 `
 
     render(front, '')


### PR DESCRIPTION
## Summary
- Add support for GitHub-style alerts using `> [!NOTE]`, `> [!TIP]`, etc.
- Five alert types: NOTE (blue), TIP (green), IMPORTANT (purple), WARNING (yellow), CAUTION (red)
- Custom CSS styling with colored left borders and tinted backgrounds
- Also fixes list item spacing (removes extra margin from `<p>` inside `<li>`)

## Syntax

```markdown
> [!NOTE]
> Useful information the user should know.

> [!TIP]
> Helpful advice for better outcomes.

> [!WARNING]
> Urgent info requiring immediate attention.
```

## Test plan
- [ ] Test all 5 alert types render correctly
- [ ] Verify colors and styling in light/dark mode
- [ ] Check kitchen sink examples