### PR TITLE
fix: disable editor settings for markdown notes

### DIFF
--- a/src/editor.css
+++ b/src/editor.css
@@ -5,6 +5,12 @@
  * wrapper class convention (see editor.ts). Only the plain-text badge needs CSS
  * to prevent users from toggling back to rich-text mode.
  */
-.anki-md-active .plain-text-badge {
-  display: none !important;
+.anki-md-active {
+  .plain-text-badge {
+    display: none !important;
+  }
+
+  #settings {
+    display: none;
+  }
 }


### PR DESCRIPTION
Closes #10

- Hide settings gear button (`#settings`) — all options are irrelevant for markdown editing
- Wrap `setCloseHTMLTags`, `setShrinkImages`, `setMathjaxEnabled` to force-disable when active
- Prevents other add-ons or Anki UI from re-enabling them