### PR TITLE
fix: ensure plain text editor is always visible

### DIFF
--- a/anki_markdown/__init__.py
+++ b/anki_markdown/__init__.py
@@ -115,14 +115,18 @@ def ensure_notetype():
         m["tmpls"][0]["qfmt"] = get_template("front.html")
         m["tmpls"][0]["afmt"] = get_template("back.html")
         m["css"] = NOTETYPE_CSS
+        for f in m["flds"]:
+            f["plainText"] = True
         mm.save(m)
         return
 
     m = mm.new(NOTETYPE)
     m["css"] = NOTETYPE_CSS
     front = mm.new_field("Front")
+    front["plainText"] = True
     mm.add_field(m, front)
     back = mm.new_field("Back")
+    back["plainText"] = True
     mm.add_field(m, back)
 
     t = mm.new_template("Default")

--- a/src/editor.css
+++ b/src/editor.css
@@ -1,29 +1,10 @@
 /*
  * Anki Markdown Editor Styles
  *
- * Hides rich-text editor UI for markdown-only editing while preserving functionality.
- *
- * Why not display:none? Anki's editor webview has features (drag-drop media, paste handling)
- * driven by the .rich-text-input element. Using display:none breaks these features.
- * Instead, we visually hide it (opacity:0, height:0) to keep it functional but invisible.
- *
- * The .anki-md-active class is toggled via JS (ankiMdActivate/ankiMdDeactivate) and only
- * applied when editing "Anki Markdown" note types, leaving other note types unaffected.
+ * Rich-text inputs are hidden per field via JS using Anki's own .hidden/.expanded
+ * wrapper class convention (see editor.ts). Only the plain-text badge needs CSS
+ * to prevent users from toggling back to rich-text mode.
  */
-.anki-md-active {
-  .editing-area {
-    gap: 0 !important;
-  }
-
-  .rich-text-input {
-    opacity: 0 !important;
-    height: 0 !important;
-    overflow: hidden !important;
-    contain: strict;
-    padding: 0 !important;
-  }
-
-  .plain-text-badge {
-    display: none !important;
-  }
+.anki-md-active .plain-text-badge {
+  display: none !important;
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,6 +1,6 @@
 /**
  * Editor integration for Anki Markdown note types.
- * Hides rich-text UI while preserving functionality.
+ * Hides rich-text input per field using Anki's own APIs.
  */
 import "./editor.css";
 
@@ -8,15 +8,30 @@ declare function require(name: string): any;
 declare const globalThis: any;
 
 const { loaded } = require("anki/ui") as { loaded: Promise<void> };
+const { instances } = require("anki/NoteEditor");
+const active = () => document.body.classList.contains("anki-md-active");
+
+/** Get boolean array matching field count. */
+const texts = async (val: boolean) =>
+  (await instances[0]?.fields)?.map(() => val);
 
 globalThis.ankiMdActivate = async () => {
   await loaded;
   document.body.classList.add("anki-md-active");
   globalThis.setCloseHTMLTags(false);
+  globalThis.setPlainTexts(await texts(true));
 };
 
 globalThis.ankiMdDeactivate = async () => {
   await loaded;
   document.body.classList.remove("anki-md-active");
   globalThis.setCloseHTMLTags(true);
+  globalThis.setPlainTexts(await texts(false));
 };
+
+/** Wrap setPlainTexts to force plain-text mode when active. */
+loaded.then(() => {
+  const orig = globalThis.setPlainTexts;
+  globalThis.setPlainTexts = (texts: boolean[]) =>
+    orig(active() ? texts.map(() => true) : texts);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,7 +35,7 @@ const editor = defineConfig({
     outDir: "anki_markdown",
     emptyOutDir: false,
     rollupOptions: {
-      external: ["anki/ui"],
+      external: (id) => /^(anki|svelte)(\/|$)/.test(id),
       output: {
         assetFileNames: "web/editor[extname]",
       },


### PR DESCRIPTION
Closes #9

- Set `plainText = True` on all fields in `ensure_notetype()` so plain text editor is the default
- Use Anki's `setPlainTexts` API to force plain-text mode at runtime
- Wrap `setPlainTexts` to prevent other add-ons or Anki internals from resetting it
- Replace CSS hacks (`opacity`, `height`, `overflow`, `contain`, `gap`) with single badge-hide rule
- Externalize all `anki/*` and `svelte/*` packages in vite config