### PR TITLE
fix: render cards progressively while Shiki loads

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -81,11 +81,12 @@ async function initHighlighter(): Promise<HighlighterCore> {
 
 const ready = initHighlighter().then((h) => (highlighter = h));
 
+let label = "text";
+
 const codeBlock: ShikiTransformer = {
   name: "code-block",
   pre(node) {
     // Move shiki class/styles from <pre> to <figure> wrapper
-    const lang = this.options.lang;
     const classes = [node.properties.class].flat().filter(Boolean) as string[];
     const style = node.properties.style;
 
@@ -106,7 +107,7 @@ const codeBlock: ShikiTransformer = {
               type: "element",
               tagName: "span",
               properties: { class: "lang" },
-              children: [{ type: "text", value: lang }],
+              children: [{ type: "text", value: label }],
             },
             {
               type: "element",
@@ -180,11 +181,12 @@ function highlight(code: string, lang: string, meta?: string) {
     if (meta) el.dataset.meta = meta;
     return el.outerHTML;
   }
-  if (!highlighter.getLoadedLanguages().includes(lang)) lang = "text";
+  label = lang;
+  const resolved = highlighter.getLoadedLanguages().includes(lang) ? lang : "text";
 
   try {
     return highlighter.codeToHtml(code, {
-      lang,
+      lang: resolved,
       themes,
       meta: { __raw: meta },
       defaultColor: false,

--- a/src/style.css
+++ b/src/style.css
@@ -110,49 +110,17 @@ body {
   }
 }
 
-.code-block {
-  margin: 0;
-  padding: 0;
-  overflow: hidden;
-  border: 1px solid var(--_border-code, var(--_border));
-  border-radius: 8px;
-  background-clip: padding-box;
-  box-shadow: var(--_shadow-code);
-  font-family: var(--_mono);
-  font-size: 0.875rem;
-
-  pre {
-    margin: 0;
-    padding: 8px;
+/* Shiki theme colors */
+.shiki {
+  span {
+    color: var(--shiki-light);
+    font-style: var(--shiki-light-font-style);
+    font-weight: var(--shiki-light-font-weight);
+    text-decoration: var(--shiki-light-text-decoration);
   }
 
-  code {
-    display: block;
-    overflow-x: auto;
-    scrollbar-width: none;
-  }
-
-  /* Shiki theme colors */
-  &.shiki {
+  &.code-block {
     background: var(--shiki-light-bg);
-
-    span {
-      color: var(--shiki-light);
-      font-style: var(--shiki-light-font-style);
-      font-weight: var(--shiki-light-font-weight);
-      text-decoration: var(--shiki-light-text-decoration);
-    }
-
-    .night-mode & {
-      background: var(--shiki-dark-bg);
-
-      span {
-        color: var(--shiki-dark);
-        font-style: var(--shiki-dark-font-style);
-        font-weight: var(--shiki-dark-font-weight);
-        text-decoration: var(--shiki-dark-text-decoration);
-      }
-    }
 
     .highlighted-word {
       background: rgb(255 255 0 / 0.2);
@@ -188,6 +156,42 @@ body {
     }
   }
 
+  .night-mode & {
+    span {
+      color: var(--shiki-dark);
+      font-style: var(--shiki-dark-font-style);
+      font-weight: var(--shiki-dark-font-weight);
+      text-decoration: var(--shiki-dark-text-decoration);
+    }
+
+    &.code-block {
+      background: var(--shiki-dark-bg);
+    }
+  }
+}
+
+.code-block {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--_border-code, var(--_border));
+  border-radius: 8px;
+  background-clip: padding-box;
+  box-shadow: var(--_shadow-code);
+  font-family: var(--_mono);
+  font-size: 0.875rem;
+
+  pre {
+    margin: 0;
+    padding: 8px;
+  }
+
+  code {
+    display: block;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
   &.has-focused .line:not(.focused) {
     opacity: 0.7;
     filter: blur(0.095rem);
@@ -199,14 +203,6 @@ body {
       opacity: 1;
       filter: blur(0);
     }
-  }
-
-  &.has-focused .toggle {
-    display: inline;
-  }
-
-  .clipboard & .copy {
-    display: inline;
   }
 
   .toolbar {
@@ -237,7 +233,7 @@ body {
       border-radius: 0.25rem;
 
       &:hover {
-        background: var(--_border-subtle);
+        background: var(--_bg-inset);
       }
     }
 
@@ -245,6 +241,14 @@ body {
     .copy {
       display: none;
     }
+  }
+
+  &.has-focused .toggle {
+    display: inline;
+  }
+
+  .clipboard & .copy {
+    display: inline;
   }
 }
 


### PR DESCRIPTION
Fixes slow 2-3 second blank screen on first card load on mobile while Shiki downloads.

- Show markdown immediately with plain `<pre><code>` fallback for code blocks
- Upgrade code blocks in-place once Shiki highlighter is ready
- Preserve `data-meta` (line/word highlights) through the upgrade
- Exclude `pre code` from inline-code CSS to prevent style flash during upgrade