### PR TITLE
feat: auto-open Chrome DevTools on debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "bun run generate && tsc && vite build && BUILD_TARGET=editor vite build",
     "package": "bun run build && cd anki_markdown && zip -r ../anki-markdown.ankiaddon . -x '__pycache__/*' '.*'",
     "preview": "vite preview",
-    "debug": "ln -sfn \"$(pwd)/anki_markdown\" ~/Library/Application\\ Support/Anki2/addons21/anki_markdown && QTWEBENGINE_REMOTE_DEBUGGING=9222 open -a Anki",
+    "debug": "bun scripts/debug.ts",
     "test": ".venv/bin/pytest tests/ -v -m offline",
     "test:online": ".venv/bin/pytest tests/ -v -m online",
     "test:all": ".venv/bin/pytest tests/ -v",

--- a/readme.md
+++ b/readme.md
@@ -104,13 +104,7 @@ Requires Anki 25.x. Note that Anki caches the add-on, so you must restart Anki f
 bun run debug
 ```
 
-This creates the symlink and launches Anki with remote debugging enabled. Then open Chrome and navigate to `chrome://inspect` to access the webview console.
-
-To do a manual symlink, run the following command:
-
-```bash
-ln -s "$(pwd)/anki_markdown" ~/Library/Application\ Support/Anki2/addons21/anki_markdown
-```
+This symlinks the add-on, launches Anki with remote debugging, waits for the main webview to load, and auto-opens Chrome DevTools for it. Requires macOS and Google Chrome.
 
 > [!TIP]
 > Install add-on [31746032](https://ankiweb.net/shared/info/31746032) for easier debugging.

--- a/scripts/debug.ts
+++ b/scripts/debug.ts
@@ -1,0 +1,56 @@
+/**
+ * Launch Anki with remote debugging and auto-open Chrome DevTools
+ * for the main webview. Requires macOS and Google Chrome.
+ */
+import { $ } from "bun";
+
+const addon = `${process.env.HOME}/Library/Application Support/Anki2/addons21/anki_markdown`;
+const port = Number(process.argv[2]) || 9230;
+
+// Quit Anki if already running (env var only applies on fresh launch)
+const running = await $`pgrep -f Anki.app/Contents/MacOS`.quiet().nothrow();
+if (running.exitCode === 0) {
+  console.log("Quitting Anki...");
+  await $`osascript -e 'tell application "Anki" to quit'`;
+  while ((await $`pgrep -f Anki.app/Contents/MacOS`.quiet().nothrow()).exitCode === 0)
+    await Bun.sleep(500);
+}
+
+// Symlink add-on
+await $`ln -sfn ${process.cwd()}/anki_markdown ${addon}`;
+
+// Launch Anki with remote debugging (invoke binary directly; `open -a` strips env vars)
+const bin = "/Applications/Anki.app/Contents/MacOS/launcher";
+const anki = Bun.spawn([bin], {
+  env: { ...process.env, QTWEBENGINE_REMOTE_DEBUGGING: String(port) },
+});
+process.on("SIGINT", () => {
+  anki.kill();
+  process.exit();
+});
+
+// Wait for main webview target
+process.stdout.write("Waiting for Anki...");
+let ws: string | undefined;
+const deadline = Date.now() + 30_000;
+while (!ws) {
+  if (Date.now() > deadline) {
+    console.error("\nTimed out waiting for Anki main webview");
+    process.exit(1);
+  }
+  try {
+    const targets: any[] = await fetch(`http://localhost:${port}/json`).then(
+      (r) => r.json(),
+    );
+    const main = targets.find((t) => t.title === "main webview");
+    if (main) ws = main.webSocketDebuggerUrl.replace("ws://", "");
+  } catch {
+    // Connection refused while Anki is starting up
+  }
+  if (!ws) await Bun.sleep(500);
+}
+console.log(" ready");
+
+// Open Chrome DevTools inspector for main webview
+const url = `devtools://devtools/bundled/inspector.html?ws=${ws}`;
+await $`osascript -e ${`tell application "Google Chrome" to open location "${url}"`}`;


### PR DESCRIPTION
- Replace inline `debug` script with `scripts/debug.ts`
- Auto-quit Anki if already running, relaunch with remote debugging
- Poll for "main webview" target with 30s timeout
- Open Chrome DevTools inspector via AppleScript (`devtools://` protocol)
- Ctrl+C kills the Anki process
- Port configurable via arg (default 9230)
- macOS only