### PR TITLE
fix: hide image float/resize toolbar in editor

### DIFF
--- a/src/editor.css
+++ b/src/editor.css
@@ -10,7 +10,9 @@
     display: none !important;
   }
 
-  #settings {
+  /* settings gear, image float/resize toolbar */
+  #settings,
+  .floating {
     display: none;
   }
 }


### PR DESCRIPTION
- Hide the `.floating` image toolbar (float-left/right/none, actual-size, restore-size) that appears when clicking images in the editor
- Not relevant for plain-text markdown editing