### PR TITLE
fix: disable CodeMirror syntax highlighting for markdown notes

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -352,16 +352,20 @@ pageTheme.subscribe((theme) => console.log(theme.isDark));
 
 #### `anki/PlainTextInput`
 
-**Purpose:** Plain text (CodeMirror) editor component API.
+**Purpose:** Plain text (CodeMirror 5) editor component API.
 
 | Export      | Description                                                      |
 | ----------- | ---------------------------------------------------------------- |
 | `lifecycle` | `{ onMount(fn), onDestroy(fn) }` - Hook into component lifecycle |
-| `instances` | Array of active PlainTextInput instances                         |
+| `instances` | Array of active `PlainTextInputAPI` instances                    |
+
+Each instance exposes `codeMirror: { editor: Promise<Editor>, setOption(key, value): Promise<void> }`.
+
+The default CodeMirror mode is `"htmlanki"` — a custom mode extending `htmlmixed` with `<anki-mathjax>` tag support (defined in `ts/editor/code-mirror.ts`). Set mode to `"null"` to disable syntax highlighting.
 
 **Note:** `closeHTMLTags` store exists in the component but is NOT exported in the package. Use `window.setCloseHTMLTags(bool)` instead (exposed globally by NoteEditor).
 
-**Source:** `ts/editor/plain-text-input/PlainTextInput.svelte`
+**Source:** `ts/editor/plain-text-input/PlainTextInput.svelte`, `ts/editor/code-mirror.ts`
 
 ---
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,12 +1,24 @@
 // Editor integration for Anki Markdown note types.
-// Hides rich-text input per field using Anki's own APIs.
+// Forces plain-text mode and disables HTML syntax highlighting.
 import "./editor.css";
 
 declare function require(name: string): any;
 declare const globalThis: any;
 
+interface CodeMirrorAPI {
+  setOption(key: string, value: unknown): Promise<void>;
+}
+
+interface PlainTextInputAPI {
+  codeMirror: CodeMirrorAPI;
+}
+
 const { loaded } = require("anki/ui") as { loaded: Promise<void> };
 const { instances } = require("anki/NoteEditor");
+const { lifecycle, instances: plainTexts } = require("anki/PlainTextInput") as {
+  lifecycle: { onMount(cb: (api: PlainTextInputAPI) => (() => void) | void): void };
+  instances: PlainTextInputAPI[];
+};
 const active = () => document.body.classList.contains("anki-md-active");
 
 // Editor settings to force-disable for markdown notes
@@ -16,11 +28,17 @@ const settings = ["setCloseHTMLTags", "setShrinkImages", "setMathjaxEnabled"];
 const fields = async (val: boolean) =>
   (await instances[0]?.fields)?.map(() => val);
 
+// Set a CodeMirror option on all plain-text inputs
+async function setOption(key: string, value: unknown): Promise<void> {
+  await Promise.all(plainTexts.map((pt) => pt.codeMirror.setOption(key, value)));
+}
+
 globalThis.ankiMdActivate = async () => {
   await loaded;
   document.body.classList.add("anki-md-active");
   for (const fn of settings) globalThis[fn](false);
   globalThis.setPlainTexts(await fields(true));
+  setOption("mode", "null");
 };
 
 globalThis.ankiMdDeactivate = async () => {
@@ -39,4 +57,9 @@ loaded.then(() => {
   const orig = globalThis.setPlainTexts;
   globalThis.setPlainTexts = (vals: boolean[]) =>
     orig(active() ? vals.map(() => true) : vals);
+});
+
+// Disable highlighting on any plain-text input that mounts while active
+lifecycle.onMount((api: PlainTextInputAPI) => {
+  if (active()) api.codeMirror.setOption("mode", "null");
 });


### PR DESCRIPTION
- Use `anki/PlainTextInput` API to set CodeMirror mode to `"null"` on activate, disabling HTML syntax highlighting in the editor
- Hook into `lifecycle.onMount` to catch fields that mount after activation
- Add generic `setOption` helper for future CodeMirror config changes
- Document `htmlanki` mode and `PlainTextInput` CodeMirror API in claude.md