### PR TITLE
feat: add Linux support to `debug.ts`

### DIFF
--- a/scripts/debug.ts
+++ b/scripts/debug.ts
@@ -3,56 +3,136 @@
  * for the main webview. Requires macOS and Google Chrome.
  */
 import { $ } from "bun";
+import os from "os";
+import process from "process";
 
-const addon = `${process.env.HOME}/Library/Application Support/Anki2/addons21/anki_markdown`;
-const port = Number(process.argv[2]) || 9230;
+// Default port on Linux is set to 9222 because this is what
+// chrome://inspect/#devices scans for by default on localhost.
+const PORT = Number(process.argv[2]) || os.platform() === "linux" ? 9222 : 9230;
 
-// Quit Anki if already running (env var only applies on fresh launch)
-const running = await $`pgrep -f Anki.app/Contents/MacOS`.quiet().nothrow();
-if (running.exitCode === 0) {
-  console.log("Quitting Anki...");
-  await $`osascript -e 'tell application "Anki" to quit'`;
-  while ((await $`pgrep -f Anki.app/Contents/MacOS`.quiet().nothrow()).exitCode === 0)
-    await Bun.sleep(500);
+// Get the addon path for the current platform.
+function addon(): string {
+  switch (os.platform()) {
+    case "linux":
+      return `${process.env.HOME}/.local/share/Anki2/addons21/anki_markdown`;
+    case "darwin":
+      return `${process.env.HOME}/Library/Application/Support/Anki2/addons21/anki_markdown`;
+    default:
+      throw new Error(`Anki addon path undefined for ${os.platform()}.`)
+  }
 }
+
+// Ensure that Anki is stopped.
+//
+// This is because environment variables are only applied
+// on fresh launch.
+async function ensureAnkiStopped(): Promise<void> {
+  switch (os.platform()) {
+    case "darwin":
+      const running = await $`pgrep -f Anki.app/Contents/MacOS`.quiet().nothrow();
+      if (running.exitCode === 0) {
+        console.log("Quitting Anki...");
+        await $`osascript -e 'tell application "Anki" to quit'`;
+        while ((await $`pgrep -f Anki.app/Contents/MacOS`.quiet().nothrow()).exitCode === 0)
+          await Bun.sleep(500);
+      }
+      break;
+    case "linux":
+      // I am not 100% sure that this is a clean way to kill Anki.
+      // Remember to always make backups :)
+      try {
+        await $`pkill -f 'python.*anki$'`
+        await $`sleep 1`;
+      } catch (err) {
+        console.warn(`Couldn't kill Anki. Perhaps it was not running in the first place? Error: ${err}`);
+      }
+      break
+    default:
+      throw new Error(`Anki killing not supported on platform = ${os.platform()}`);
+  }
+}
+
+async function launchAnki(): Promise<{frontend: string, anki: unknown}> {
+  let bin: string;
+  switch (os.platform()) {
+    case "darwin":
+      // Launch Anki with remote debugging (invoke binary directly; `open -a` strips env vars)
+      bin = "/Applications/Anki.app/Contents/MacOS/launcher";
+      break;
+    case "linux":
+      // Dynamically get Anki's path.
+      let resp = await $`which anki`;
+      if (resp.exitCode !== 0) {
+        throw new Error(`'which anki' failed with exit code ${resp.exitCode}`)
+      }
+      bin = resp.stdout.toString().trim();
+      console.log(bin)
+      break
+    default:
+      throw new Error(`Anki launching not supported on platform = ${os.platform()}`);
+  }
+
+  const anki = Bun.spawn([bin], {
+    env: { ...process.env, QTWEBENGINE_REMOTE_DEBUGGING: String(PORT) },
+  });
+
+  process.on("SIGINT", () => {
+    anki.kill();
+    process.exit();
+  });
+
+  // Wait for main webview target
+  process.stdout.write("Waiting for Anki...");
+  let frontend: string | undefined;
+  const deadline = Date.now() + 30_000;
+  while (!frontend) {
+    if (Date.now() > deadline) {
+      console.error("\nTimed out waiting for Anki main webview");
+      process.exit(1);
+    }
+    try {
+      const targets: any[] = await fetch(`http://localhost:${PORT}/json`).then(
+        (r) => r.json(),
+      );
+      const main = targets.find((t) => t.title === "main webview");
+      if (main) frontend = main.devtoolsFrontendUrl;
+    } catch (err) {
+      console.warn(`error while trying to fetch DevTools' /json: ${err}`);
+    }
+    if (!frontend) await Bun.sleep(500);
+  }
+
+  return {frontend, anki};
+}
+
+// Launch the DevTools window.
+//
+// Contributions to make this automated on Linux are
+// welcome!
+async function launchDevtools(url: string): Promise<void> {
+  switch (os.platform()) {
+    case "linux":
+      console.warn("Opening DevTools automatically is not supported on Linux. Open Chromium and navigate to chrome://inspect/#devices to open.")
+      break
+    case "darwin":
+      await $`osascript -e ${`tell application "Google Chrome" to open location "${url}"`}`;
+      break;
+    default:
+      throw new Error(`DevTools launching not supported on ${os.platform()}`);
+  }
+}
+
+await ensureAnkiStopped();
 
 // Symlink add-on
-await $`ln -sfn ${process.cwd()}/anki_markdown ${addon}`;
+await $`ln -sfn ${process.cwd()}/anki_markdown ${addon()}`;
 
-// Launch Anki with remote debugging (invoke binary directly; `open -a` strips env vars)
-const bin = "/Applications/Anki.app/Contents/MacOS/launcher";
-const anki = Bun.spawn([bin], {
-  env: { ...process.env, QTWEBENGINE_REMOTE_DEBUGGING: String(port) },
-});
-process.on("SIGINT", () => {
-  anki.kill();
-  process.exit();
-});
+const {frontend, anki} = await launchAnki();
 
-// Wait for main webview target
-process.stdout.write("Waiting for Anki...");
-let frontend: string | undefined;
-const deadline = Date.now() + 30_000;
-while (!frontend) {
-  if (Date.now() > deadline) {
-    console.error("\nTimed out waiting for Anki main webview");
-    process.exit(1);
-  }
-  try {
-    const targets: any[] = await fetch(`http://localhost:${port}/json`).then(
-      (r) => r.json(),
-    );
-    const main = targets.find((t) => t.title === "main webview");
-    if (main) frontend = main.devtoolsFrontendUrl;
-  } catch {
-    // Connection refused while Anki is starting up
-  }
-  if (!frontend) await Bun.sleep(500);
-}
 console.log(" ready");
 
 // Open Qt WebEngine's own DevTools frontend (avoids Chrome protocol mismatch)
-const url = `http://localhost:${port}${frontend}`;
-await $`osascript -e ${`tell application "Google Chrome" to open location "${url}"`}`;
+const url = `http://localhost:${PORT}${frontend}`;
+await launchDevtools(url)
 
 await anki.exited;

--- a/scripts/debug.ts
+++ b/scripts/debug.ts
@@ -8,7 +8,7 @@ import process from "process";
 
 // Default port on Linux is set to 9222 because this is what
 // chrome://inspect/#devices scans for by default on localhost.
-const PORT = Number(process.argv[2]) || os.platform() === "linux" ? 9222 : 9230;
+const PORT = Number(process.argv[2]) || (os.platform() === "linux" ? 9222 : 9230);
 
 // Get the addon path for the current platform.
 function addon(): string {
@@ -28,7 +28,7 @@ function addon(): string {
 // on fresh launch.
 async function ensureAnkiStopped(): Promise<void> {
   switch (os.platform()) {
-    case "darwin":
+    case "darwin": {
       const running = await $`pgrep -f Anki.app/Contents/MacOS`.quiet().nothrow();
       if (running.exitCode === 0) {
         console.log("Quitting Anki...");
@@ -37,12 +37,13 @@ async function ensureAnkiStopped(): Promise<void> {
           await Bun.sleep(500);
       }
       break;
+    }
     case "linux":
       // I am not 100% sure that this is a clean way to kill Anki.
       // Remember to always make backups :)
       try {
         await $`pkill -f 'python.*anki$'`
-        await $`sleep 1`;
+        await Bun.sleep(1000);
       } catch (err) {
         console.warn(`Couldn't kill Anki. Perhaps it was not running in the first place? Error: ${err}`);
       }
@@ -52,14 +53,14 @@ async function ensureAnkiStopped(): Promise<void> {
   }
 }
 
-async function launchAnki(): Promise<{frontend: string, anki: unknown}> {
+async function launchAnki(): Promise<{frontend: string, anki: Subprocess}> {
   let bin: string;
   switch (os.platform()) {
     case "darwin":
       // Launch Anki with remote debugging (invoke binary directly; `open -a` strips env vars)
       bin = "/Applications/Anki.app/Contents/MacOS/launcher";
       break;
-    case "linux":
+    case "linux": {
       // Dynamically get Anki's path.
       let resp = await $`which anki`;
       if (resp.exitCode !== 0) {
@@ -67,6 +68,7 @@ async function launchAnki(): Promise<{frontend: string, anki: unknown}> {
       }
       bin = resp.stdout.toString().trim();
       break
+    }
     default:
       throw new Error(`Anki launching not supported on platform = ${os.platform()}`);
   }

--- a/scripts/debug.ts
+++ b/scripts/debug.ts
@@ -66,7 +66,6 @@ async function launchAnki(): Promise<{frontend: string, anki: unknown}> {
         throw new Error(`'which anki' failed with exit code ${resp.exitCode}`)
       }
       bin = resp.stdout.toString().trim();
-      console.log(bin)
       break
     default:
       throw new Error(`Anki launching not supported on platform = ${os.platform()}`);


### PR DESCRIPTION
This PR allows starting `debug.ts` on Linux.

## Missing feature

As far as I could understand, it's not possible to directly open DevTools from the command line on Linux.
This is the only difference with MacOS.

## Verification instructions

I don't currently have a MacOS device to test that `debug.ts` works as intended. It needs manual testing before being merged.

I think this should do the trick:

1. `cd /tmp`
2. `git clone https://github.com/clouedoc/anki-markdown.git`
3. `cd anki-markdown`
4. `git checkout fork`
5. `bun run build`
6. `bun run dev` + manually checking that Anki and DevTools launch automatically like it did before.

---

Thank you !