### PR TITLE
fix: render in light mode on AnkiWeb

### DIFF
--- a/ankiweb.md
+++ b/ankiweb.md
@@ -5,7 +5,7 @@ Write flashcards in Markdown with the same syntax highlighting you know from you
 - **Full Markdown** with bold, italic, lists, blockquotes, tables, images, alerts, and more
 - **Clean card design** with polished light/dark styling that matches Anki's native UI
 - **Settings panel** to dynamically pick languages and themes
-- **Mobile** works on AnkiDroid and AnkiMobile
+- **Cross-platform** works on desktop, AnkiDroid, AnkiMobile, and AnkiWeb
 - **AI agent friendly** built-in [agent skill](https://github.com/terkelg/anki-markdown#ai-agent-skill) lets AI agents create and manage flashcards via [AnkiConnect](https://foosoft.net/projects/anki-connect/)
 
 See the [documentation](https://github.com/terkelg/anki-markdown/blob/main/docs.md) for all features and syntax guide.

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Anki add-on for Markdown notes with syntax highlighting powered by [Shiki](https://shiki.style)
 
-Write flashcards in Markdown with full [syntax highlighting](docs.md#code-blocks). Pick from 300+ languages and 60+ themes — only your selections are downloaded and synced. Supports light and dark mode across desktop and mobile.
+Write flashcards in Markdown with full [syntax highlighting](docs.md#code-blocks). Pick from 300+ languages and 60+ themes — only your selections are downloaded and synced. Supports light and dark mode across desktop, mobile, and AnkiWeb.
 
 <p align="center">
   <picture>
@@ -20,7 +20,7 @@ Write flashcards in Markdown with full [syntax highlighting](docs.md#code-blocks
 - **Full Markdown** with bold, italic, lists, blockquotes, tables, images, alerts, and more
 - **Clean card design** with polished light/dark styling that matches Anki's native UI
 - **Settings panel** to dynamically pick languages and themes
-- **Mobile** works on AnkiDroid and AnkiMobile
+- **Cross-platform** works on desktop, AnkiDroid, AnkiMobile, and AnkiWeb
 - **[AI agent skill](#ai-agent-skill)** built-in skill that lets AI agents create markdown flashcards via [AnkiConnect](https://foosoft.net/projects/anki-connect/)
 
 ## Usage

--- a/src/render.ts
+++ b/src/render.ts
@@ -349,19 +349,22 @@ function upgrade(container: HTMLElement) {
   }
 }
 
-// Normalize dark mode classes into .night-mode on :root
+// Mirror the host's dark-mode class onto our wrapper so theming stays scoped.
 // - Desktop: nightMode + night_mode on <body> (qt/aqt/theme.py body_classes_for_card_ord)
 //   https://github.com/ankitects/anki/blob/main/qt/aqt/theme.py
 // - AnkiDroid: night_mode on <body>
 //   https://github.com/ankidroid/Anki-Android/wiki/Advanced-formatting
 // - AnkiMobile: nightMode on card element
 //   https://docs.ankimobile.net/night-mode.html
-function normalizeDarkMode() {
+// - AnkiWeb: no class — always light
+function normalizeDarkMode(wrapper: HTMLElement | null) {
+  if (!wrapper) return;
+  const card = document.querySelector(".card");
   const dark =
     document.body.classList.contains("nightMode") ||
     document.body.classList.contains("night_mode") ||
-    matchMedia("(prefers-color-scheme: dark)").matches;
-  if (dark) document.documentElement.classList.add("night-mode");
+    card?.classList.contains("nightMode");
+  if (dark) wrapper.classList.add("night-mode");
 }
 
 async function upgradeHighlighter(...els: (HTMLElement | null)[]) {
@@ -377,8 +380,8 @@ async function upgradeHighlighter(...els: (HTMLElement | null)[]) {
 
 /** Render front/back fields to card DOM. */
 export async function render(front: string, back: string) {
-  const wrapper = document.querySelector(".anki-md-wrapper");
-  normalizeDarkMode();
+  const wrapper = document.querySelector<HTMLElement>(".anki-md-wrapper");
+  normalizeDarkMode(wrapper);
 
   const frontEl = document.querySelector<HTMLElement>(".front");
   const backEl = document.querySelector<HTMLElement>(".back");
@@ -398,8 +401,8 @@ export async function render(front: string, back: string) {
 
 /** Render cloze deletion card to DOM. */
 export async function renderCloze(text: string, extra: string, ordinal: number, side: Side) {
-  const wrapper = document.querySelector(".anki-md-wrapper");
-  normalizeDarkMode();
+  const wrapper = document.querySelector<HTMLElement>(".anki-md-wrapper");
+  normalizeDarkMode(wrapper);
 
   const frontEl = document.querySelector<HTMLElement>(".front");
   const backEl = document.querySelector<HTMLElement>(".back");

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
-:root {
+.anki-md-wrapper {
   --_mono: "Berkeley Mono Variable", ui-monospace, "JetBrains Mono", "Fira Code", monospace;
   --_radius: var(--border-radius, 5px);
   --_fg: var(--fg, #020202);
@@ -154,7 +154,7 @@ body {
     }
   }
 
-  .night-mode & {
+  .anki-md-wrapper.night-mode & {
     span {
       color: var(--shiki-dark);
       font-style: var(--shiki-dark-font-style);
@@ -269,7 +269,7 @@ mark {
   padding: 1px 2px;
   border-radius: 2px;
 
-  .night-mode & {
+  .anki-md-wrapper.night-mode & {
     background: rgb(255 255 0 / 0.4);
   }
 }
@@ -390,7 +390,7 @@ kbd {
     background: rgb(0 0 0 / 0.06);
     border-color: rgb(0 0 0 / 0.1);
 
-    .night-mode & {
+    .anki-md-wrapper.night-mode & {
       background: rgb(255 255 255 / 0.1);
       border-color: rgb(255 255 255 / 0.15);
     }


### PR DESCRIPTION
- AnkiWeb doesn't set any `nightMode`/`night_mode` class, so the old `prefers-color-scheme: dark` fallback was flipping cards to dark even though AnkiWeb itself is always light
- Drop the media-query fallback and also check `.card` element (covers AnkiMobile per upstream docs)
- Mirror the resulting class onto our `.anki-md-wrapper` instead of `document.documentElement` so theming stays scoped to our subtree
- CSS vars moved from `:root` to `.anki-md-wrapper`; three `.night-mode &` selectors qualified as `.anki-md-wrapper.night-mode &`
- Docs updated: "Mobile" bullet becomes "Cross-platform" mentioning AnkiWeb

Verified live against https://ankiuser.net/study — card renders in light mode after sync.