### PR TITLE
fix: preserve raw template field text

### DIFF
--- a/anki_markdown/templates/back.html
+++ b/anki_markdown/templates/back.html
@@ -3,7 +3,9 @@
   <div class="front"></div>
   <div class="back"></div>
 </div>
+<!-- prettier-ignore -->
 <script id="data-front" type="text/plain">{{Front}}</script>
+<!-- prettier-ignore -->
 <script id="data-back" type="text/plain">{{Back}}</script>
 <script type="module">
   import { render } from "./_review.js";

--- a/anki_markdown/templates/back.html
+++ b/anki_markdown/templates/back.html
@@ -3,12 +3,8 @@
   <div class="front"></div>
   <div class="back"></div>
 </div>
-<script id="data-front" type="text/plain">
-  {{Front}}
-</script>
-<script id="data-back" type="text/plain">
-  {{Back}}
-</script>
+<script id="data-front" type="text/plain">{{Front}}</script>
+<script id="data-back" type="text/plain">{{Back}}</script>
 <script type="module">
   import { render } from "./_review.js";
   const front = document.getElementById("data-front").textContent;

--- a/anki_markdown/templates/cloze-back.html
+++ b/anki_markdown/templates/cloze-back.html
@@ -6,7 +6,9 @@
 <!-- Anki requires {{cloze:Text}} in the template to generate cards per cloze number.
      Hidden because we render cloze ourselves in JS from the raw {{Text}} field below. -->
 <div style="display: none">{{cloze:Text}}</div>
+<!-- prettier-ignore -->
 <script id="data-text" type="text/plain">{{Text}}</script>
+<!-- prettier-ignore -->
 <script id="data-extra" type="text/plain">{{Extra}}</script>
 <script type="module">
   import { renderCloze } from "./_review.js";

--- a/anki_markdown/templates/cloze-back.html
+++ b/anki_markdown/templates/cloze-back.html
@@ -6,12 +6,8 @@
 <!-- Anki requires {{cloze:Text}} in the template to generate cards per cloze number.
      Hidden because we render cloze ourselves in JS from the raw {{Text}} field below. -->
 <div style="display: none">{{cloze:Text}}</div>
-<script id="data-text" type="text/plain">
-  {{Text}}
-</script>
-<script id="data-extra" type="text/plain">
-  {{Extra}}
-</script>
+<script id="data-text" type="text/plain">{{Text}}</script>
+<script id="data-extra" type="text/plain">{{Extra}}</script>
 <script type="module">
   import { renderCloze } from "./_review.js";
   const text = document.getElementById("data-text").textContent;

--- a/anki_markdown/templates/cloze-front.html
+++ b/anki_markdown/templates/cloze-front.html
@@ -5,12 +5,8 @@
 <!-- Anki requires {{cloze:Text}} in the template to generate cards per cloze number.
      Hidden because we render cloze ourselves in JS from the raw {{Text}} field below. -->
 <div style="display: none">{{cloze:Text}}</div>
-<script id="data-text" type="text/plain">
-  {{Text}}
-</script>
-<script id="data-extra" type="text/plain">
-  {{Extra}}
-</script>
+<script id="data-text" type="text/plain">{{Text}}</script>
+<script id="data-extra" type="text/plain">{{Extra}}</script>
 <script type="module">
   import { renderCloze } from "./_review.js";
   const text = document.getElementById("data-text").textContent;

--- a/anki_markdown/templates/cloze-front.html
+++ b/anki_markdown/templates/cloze-front.html
@@ -5,7 +5,9 @@
 <!-- Anki requires {{cloze:Text}} in the template to generate cards per cloze number.
      Hidden because we render cloze ourselves in JS from the raw {{Text}} field below. -->
 <div style="display: none">{{cloze:Text}}</div>
+<!-- prettier-ignore -->
 <script id="data-text" type="text/plain">{{Text}}</script>
+<!-- prettier-ignore -->
 <script id="data-extra" type="text/plain">{{Extra}}</script>
 <script type="module">
   import { renderCloze } from "./_review.js";

--- a/anki_markdown/templates/front.html
+++ b/anki_markdown/templates/front.html
@@ -2,12 +2,8 @@
 <div class="anki-md-wrapper">
   <div class="front"></div>
 </div>
-<script id="data-front" type="text/plain">
-  {{Front}}
-</script>
-<script id="data-back" type="text/plain">
-  {{Back}}
-</script>
+<script id="data-front" type="text/plain">{{Front}}</script>
+<script id="data-back" type="text/plain">{{Back}}</script>
 <script type="module">
   import { render } from "./_review.js";
   const front = document.getElementById("data-front").textContent;

--- a/anki_markdown/templates/front.html
+++ b/anki_markdown/templates/front.html
@@ -2,7 +2,9 @@
 <div class="anki-md-wrapper">
   <div class="front"></div>
 </div>
+<!-- prettier-ignore -->
 <script id="data-front" type="text/plain">{{Front}}</script>
+<!-- prettier-ignore -->
 <script id="data-back" type="text/plain">{{Back}}</script>
 <script type="module">
   import { render } from "./_review.js";

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,57 @@
+from html.parser import HTMLParser
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+SAMPLE = """1. 短期
+   - NAT
+   - L4, L7 反向代理
+1. 中/长期
+   - 逐步重新规划 IP"""
+
+
+class Scripts(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.out = {}
+        self.key = None
+
+    def handle_starttag(self, tag, attrs):
+        vals = dict(attrs)
+        if tag == "script" and vals.get("type") == "text/plain":
+            self.key = vals.get("id")
+            self.out[self.key] = []
+
+    def handle_data(self, data):
+        if self.key:
+            self.out[self.key].append(data)
+
+    def handle_endtag(self, tag):
+        if tag == "script":
+            self.key = None
+
+
+def read(file, vals):
+    text = (ROOT / "anki_markdown" / "templates" / file).read_text(encoding="utf-8")
+    for raw, val in vals.items():
+        text = text.replace(raw, val)
+    parser = Scripts()
+    parser.feed(text)
+    return {key: "".join(val) for key, val in parser.out.items()}
+
+
+@pytest.mark.parametrize(
+    ("file", "vals", "keys"),
+    [
+        ("front.html", {"{{Front}}": SAMPLE, "{{Back}}": SAMPLE}, ("data-front", "data-back")),
+        ("back.html", {"{{Front}}": SAMPLE, "{{Back}}": SAMPLE}, ("data-front", "data-back")),
+        ("cloze-front.html", {"{{Text}}": SAMPLE, "{{Extra}}": SAMPLE}, ("data-text", "data-extra")),
+        ("cloze-back.html", {"{{Text}}": SAMPLE, "{{Extra}}": SAMPLE}, ("data-text", "data-extra")),
+    ],
+)
+def test_field_scripts_keep_raw_text(file, vals, keys):
+    out = read(file, vals)
+
+    for key in keys:
+        assert out[key] == SAMPLE


### PR DESCRIPTION
- Keeps raw markdown field substitutions inline in all review templates so Anki does not prefix the first field line with template spaces.
- Adds a regression test that substitutes the issue sample into each text/plain data script and verifies the extracted text stays unchanged.
- Fixes #43.
- Verified with `.venv/bin/pytest tests/ -v -m offline`.