### PR TITLE
fix: preserve markdown field indentation

### DIFF
--- a/anki_markdown/templates/back.html
+++ b/anki_markdown/templates/back.html
@@ -3,12 +3,8 @@
   <div class="front"></div>
   <div class="back"></div>
 </div>
-<script id="data-front" type="text/plain">
-  {{Front}}
-</script>
-<script id="data-back" type="text/plain">
-  {{Back}}
-</script>
+<script id="data-front" type="text/plain">{{Front}}</script>
+<script id="data-back" type="text/plain">{{Back}}</script>
 <script type="module">
   import { render } from "./_review.js";
   const front = document.getElementById("data-front").textContent;

--- a/anki_markdown/templates/cloze-back.html
+++ b/anki_markdown/templates/cloze-back.html
@@ -6,12 +6,8 @@
 <!-- Anki requires {{cloze:Text}} in the template to generate cards per cloze number.
      Hidden because we render cloze ourselves in JS from the raw {{Text}} field below. -->
 <div style="display: none">{{cloze:Text}}</div>
-<script id="data-text" type="text/plain">
-  {{Text}}
-</script>
-<script id="data-extra" type="text/plain">
-  {{Extra}}
-</script>
+<script id="data-text" type="text/plain">{{Text}}</script>
+<script id="data-extra" type="text/plain">{{Extra}}</script>
 <script type="module">
   import { renderCloze } from "./_review.js";
   const text = document.getElementById("data-text").textContent;

--- a/anki_markdown/templates/cloze-front.html
+++ b/anki_markdown/templates/cloze-front.html
@@ -5,12 +5,8 @@
 <!-- Anki requires {{cloze:Text}} in the template to generate cards per cloze number.
      Hidden because we render cloze ourselves in JS from the raw {{Text}} field below. -->
 <div style="display: none">{{cloze:Text}}</div>
-<script id="data-text" type="text/plain">
-  {{Text}}
-</script>
-<script id="data-extra" type="text/plain">
-  {{Extra}}
-</script>
+<script id="data-text" type="text/plain">{{Text}}</script>
+<script id="data-extra" type="text/plain">{{Extra}}</script>
 <script type="module">
   import { renderCloze } from "./_review.js";
   const text = document.getElementById("data-text").textContent;

--- a/anki_markdown/templates/front.html
+++ b/anki_markdown/templates/front.html
@@ -2,12 +2,8 @@
 <div class="anki-md-wrapper">
   <div class="front"></div>
 </div>
-<script id="data-front" type="text/plain">
-  {{Front}}
-</script>
-<script id="data-back" type="text/plain">
-  {{Back}}
-</script>
+<script id="data-front" type="text/plain">{{Front}}</script>
+<script id="data-back" type="text/plain">{{Back}}</script>
 <script type="module">
   import { render } from "./_review.js";
   const front = document.getElementById("data-front").textContent;

--- a/tests/test_addon_init.py
+++ b/tests/test_addon_init.py
@@ -2,6 +2,7 @@ import importlib.util
 import json
 import sys
 import types
+from html.parser import HTMLParser
 from pathlib import Path
 
 import pytest
@@ -159,6 +160,26 @@ class FakeBackend:
                 "tmpls": [{"name": "Cloze", "qfmt": "stock-front", "afmt": "stock-back"}],
             }
         )
+
+
+class Script(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.key = None
+        self.data = {}
+
+    def handle_starttag(self, tag, attrs):
+        attr = dict(attrs)
+        if tag == "script" and attr.get("type") == "text/plain" and attr.get("id"):
+            self.key = attr["id"]
+
+    def handle_data(self, data):
+        if self.key:
+            self.data[self.key] = self.data.get(self.key, "") + data
+
+    def handle_endtag(self, tag):
+        if tag == "script":
+            self.key = None
 
 
 @pytest.fixture
@@ -367,6 +388,25 @@ class TestEnsureClozeNotetype:
         assert model["tmpls"][0]["afmt"].endswith("<div>cloze-back</div>")
         assert [f["name"] for f in model["flds"]] == ["Text", "Extra"]
         assert all(f["plainText"] is True for f in model["flds"])
+
+
+class TestTemplates:
+    def test_raw_scripts_preserve_field_indentation(self):
+        sample = "1. Parent\n   - Child"
+        cases = {
+            "front.html": {"data-front": "{{Front}}", "data-back": "{{Back}}"},
+            "back.html": {"data-front": "{{Front}}", "data-back": "{{Back}}"},
+            "cloze-front.html": {"data-text": "{{Text}}", "data-extra": "{{Extra}}"},
+            "cloze-back.html": {"data-text": "{{Text}}", "data-extra": "{{Extra}}"},
+        }
+
+        for file, ids in cases.items():
+            text = (PKG / "templates" / file).read_text(encoding="utf-8")
+            for key, token in ids.items():
+                script = Script()
+                script.feed(text.replace(token, sample))
+
+                assert script.data[key] == sample
 
 
 class TestSyncMedia:


### PR DESCRIPTION
- Fixes #43 by keeping raw field substitutions inline inside the reviewer text/plain scripts.
- Prevents template indentation from being prepended to markdown content, preserving nested list indentation.
- Adds a regression test for all basic and cloze raw field script ids.
- Verified with `vp run test`.